### PR TITLE
Add refreshMap method handler for Google map object

### DIFF
--- a/jquery.timezone-picker.js
+++ b/jquery.timezone-picker.js
@@ -89,12 +89,17 @@
       _map.lastInfoWindow = infowindow;
     };
 
+    var refreshMap = function() {
+        google.maps.event.trigger(_map, 'resize'); 
+    }
+
     return {
       addPolygon: addPolygon,
       createPoint: createPoint,
       hideInfoWindow: hideInfoWindow,
       removePolygon: removePolygon,
-      showInfoWindow: showInfoWindow
+      showInfoWindow: showInfoWindow,
+      refreshMap: refreshMap
     };
   };
 
@@ -727,9 +732,14 @@
           }
         });
       }
+    },
+    refreshMap: function () {
+        if (_mapper.refreshMap) {  
+            _mapper.refreshMap();
+        }
     }
   };
-
+    
   $.fn.timezonePicker = function(method) {
 
     if (methods[method]) {


### PR DESCRIPTION
This patch helps me with #14... calling refreshMap after making the map visible causes it to redraw as expected.  

This isn't complete -- it doesn't add a comparable method to OpenLayers maps.  Also, I am still seeing some inexplicable behavior with the map centering behavior (there is an odd relationship between the initialLat and initialLong that I pass in with the appearance of the map) which I don't see on the first render of the unpatched version.  So it's not really a candidate for pull.  But I thought I would put this up in case someone else who knows more than I do can work on it a bit. 
