### PR TITLE
updated to work with jquery ~3

### DIFF
--- a/jquery.timezone-picker.js
+++ b/jquery.timezone-picker.js
@@ -389,7 +389,7 @@
 
         selectPolygonZone(result.selectedPolygon);
       }
-    }).error(function() {
+    }).fail(function() {
       console.warn(arguments);
     });
   };


### PR DESCRIPTION
Replaced deprecated jqXHR $.get().error() callback with new jQuery 3 $.get().fail() callback (as noted [here](https://api.jquery.com/jquery.get/#jqxhr-object))
